### PR TITLE
[chore] fix inconsistent component state update in example code

### DIFF
--- a/examples/doubleUpdate.js
+++ b/examples/doubleUpdate.js
@@ -35,9 +35,9 @@ class App extends React.Component {
   }
 
   switch = () => {
-    this.setState({
-      items: this.state.items.length ? [] : this.items,
-    });
+    this.setState(state => ({
+      items: state.items.length ? [] : this.items,
+    }));
   }
   remove = () => {
     console.log('remove: 1');


### PR DESCRIPTION
React component state updates using `setState` may asynchronously update `this.props` and `this.state`, thus it is not safe to use either of the two when calculating the new state passed to `setState`, and instead the callback-based variant should be used instead. ([details here](https://lgtm.com/rules/1819283066/)).

This was [found on LGTM.com](https://lgtm.com/projects/g/react-component/queue-anim/alerts), and other than the alert mentioned in #68, there are no others remaining.

*(Full disclosure: I'm part of the team behind LGTM.com)*
